### PR TITLE
Add `From<u8>` and `From<char>` to `Quotable` (alternative implementation)

### DIFF
--- a/src/bash.rs
+++ b/src/bash.rs
@@ -124,6 +124,7 @@ impl Bash {
     ///
     pub fn quote_vec<'a, S: ?Sized + Into<Quotable<'a>>>(s: S) -> Vec<u8> {
         match s.into() {
+            Quotable::Byte(byte) => Self::quote_vec(&[byte]),
             Quotable::Bytes(bytes) => match bytes::escape_prepare(bytes) {
                 bytes::Prepared::Empty => vec![b'\'', b'\''],
                 bytes::Prepared::Inert => bytes.into(),
@@ -137,6 +138,7 @@ impl Bash {
                     sout
                 }
             },
+            Quotable::Char(ch) => Self::quote_vec(&ch.to_string()),
             Quotable::Text(text) => match text::escape_prepare(text) {
                 text::Prepared::Empty => vec![b'\'', b'\''],
                 text::Prepared::Inert => text.into(),
@@ -170,6 +172,7 @@ impl Bash {
     ///
     pub fn quote_into_vec<'a, S: ?Sized + Into<Quotable<'a>>>(s: S, sout: &mut Vec<u8>) {
         match s.into() {
+            Quotable::Byte(byte) => Self::quote_into_vec(&[byte], sout),
             Quotable::Bytes(bytes) => match bytes::escape_prepare(bytes) {
                 bytes::Prepared::Empty => sout.extend(b"''"),
                 bytes::Prepared::Inert => sout.extend(bytes),
@@ -184,6 +187,7 @@ impl Bash {
                     debug_assert_eq!(cap, sout.capacity()); // No reallocations.
                 }
             },
+            Quotable::Char(ch) => Self::quote_into_vec(&ch.to_string(), sout),
             Quotable::Text(text) => match text::escape_prepare(text) {
                 text::Prepared::Empty => sout.extend(b"''"),
                 text::Prepared::Inert => sout.extend(text.as_bytes()),

--- a/src/fish.rs
+++ b/src/fish.rs
@@ -90,6 +90,7 @@ impl Fish {
     /// ```
     pub fn quote_vec<'a, S: ?Sized + Into<Quotable<'a>>>(s: S) -> Vec<u8> {
         match s.into() {
+            Quotable::Byte(byte) => Self::quote_vec(&[byte]),
             Quotable::Bytes(bytes) => match bytes::escape_prepare(bytes) {
                 bytes::Prepared::Empty => vec![b'\'', b'\''],
                 bytes::Prepared::Inert => bytes.into(),
@@ -99,6 +100,7 @@ impl Fish {
                     sout
                 }
             },
+            Quotable::Char(ch) => Self::quote_vec(&ch.to_string()),
             Quotable::Text(text) => match text::escape_prepare(text) {
                 text::Prepared::Empty => vec![b'\'', b'\''],
                 text::Prepared::Inert => text.into(),
@@ -128,6 +130,7 @@ impl Fish {
     ///
     pub fn quote_into_vec<'a, S: ?Sized + Into<Quotable<'a>>>(s: S, sout: &mut Vec<u8>) {
         match s.into() {
+            Quotable::Byte(byte) => Self::quote_into_vec(&[byte], sout),
             Quotable::Bytes(bytes) => match bytes::escape_prepare(bytes) {
                 bytes::Prepared::Empty => sout.extend(b"''"),
                 bytes::Prepared::Inert => sout.extend(bytes),
@@ -136,6 +139,7 @@ impl Fish {
                     bytes::escape_chars(esc, sout); // Do the work.
                 }
             },
+            Quotable::Char(ch) => Self::quote_into_vec(&ch.to_string(), sout),
             Quotable::Text(text) => match text::escape_prepare(text) {
                 text::Prepared::Empty => sout.extend(b"''"),
                 text::Prepared::Inert => sout.extend(text.as_bytes()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,12 +111,34 @@ pub enum Quotable<'a> {
         not(any(feature = "bash", feature = "fish", feature = "sh")),
         allow(unused)
     )]
+    Byte(u8),
+    #[cfg_attr(
+        not(any(feature = "bash", feature = "fish", feature = "sh")),
+        allow(unused)
+    )]
     Bytes(&'a [u8]),
     #[cfg_attr(
         not(any(feature = "bash", feature = "fish", feature = "sh")),
         allow(unused)
     )]
+    Char(char),
+    #[cfg_attr(
+        not(any(feature = "bash", feature = "fish", feature = "sh")),
+        allow(unused)
+    )]
     Text(&'a str),
+}
+
+impl From<u8> for Quotable<'static> {
+    fn from(source: u8) -> Quotable<'static> {
+        Quotable::Byte(source)
+    }
+}
+
+impl From<char> for Quotable<'static> {
+    fn from(source: char) -> Quotable<'static> {
+        Quotable::Char(source)
+    }
 }
 
 impl<'a> From<&'a [u8]> for Quotable<'a> {


### PR DESCRIPTION
Fixes #23, but `u8`/`char` only; not iterator. Adding iterator support results in conflicting impls. The ergonomics of more generality are poor in this instance. This is one of two alternative implementations. I'm not sure which I want to merge, or if I want to merge either of them.