### PR TITLE
Tests for carriage return and newline handling for all shells

### DIFF
--- a/tests/test_bash.rs
+++ b/tests/test_bash.rs
@@ -39,6 +39,7 @@ mod bash_impl {
     #[test]
     fn test_punctuation() {
         assert_eq!(Bash::quote_vec("-_=/,.+"), b"$'-_=/,.+'");
+        assert_eq!(Bash::quote_vec("Hello \r\n"), b"$'Hello \\r\\n'");
     }
 
     #[test]

--- a/tests/test_fish.rs
+++ b/tests/test_fish.rs
@@ -72,6 +72,7 @@ mod fish_impl {
     #[test]
     fn test_punctuation() {
         assert_eq!(Fish::quote_vec("-_=/,.+"), b"-_'=/,.+'");
+        assert_eq!(Fish::quote_vec("Hello \r\n"), b"Hello' '\\r\\n");
     }
 
     #[test]

--- a/tests/test_sh.rs
+++ b/tests/test_sh.rs
@@ -67,6 +67,7 @@ mod sh_impl {
     #[test]
     fn test_punctuation() {
         assert_eq!(Sh::quote_vec("-_=/,.+"), b"-_'=/,.+'");
+        assert_eq!(Sh::quote_vec("Hello \r\n"), b"Hello' \r\n'");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #19. Turns out that newlines are already escaped for Bash and fish, so this only adds explicit tests.