### PR TITLE
Remove `?Sized` bounds because they're ignored

### DIFF
--- a/src/bash.rs
+++ b/src/bash.rs
@@ -70,20 +70,20 @@ pub struct Bash;
 // ----------------------------------------------------------------------------
 
 impl QuoteInto<Vec<u8>> for Bash {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut Vec<u8>) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut Vec<u8>) {
         Self::quote_into_vec(s, out);
     }
 }
 
 impl QuoteInto<String> for Bash {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut String) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut String) {
         Self::quote_into_vec(s, unsafe { out.as_mut_vec() })
     }
 }
 
 #[cfg(unix)]
 impl QuoteInto<std::ffi::OsString> for Bash {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut std::ffi::OsString) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut std::ffi::OsString) {
         use std::os::unix::ffi::OsStringExt;
         let s = Self::quote_vec(s);
         let s = std::ffi::OsString::from_vec(s);
@@ -93,7 +93,7 @@ impl QuoteInto<std::ffi::OsString> for Bash {
 
 #[cfg(feature = "bstr")]
 impl QuoteInto<bstr::BString> for Bash {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut bstr::BString) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut bstr::BString) {
         let s = Self::quote_vec(s);
         out.extend(s);
     }
@@ -122,7 +122,7 @@ impl Bash {
     /// [ansi-c-quoting]:
     ///     https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html
     ///
-    pub fn quote_vec<'a, S: ?Sized + Into<Quotable<'a>>>(s: S) -> Vec<u8> {
+    pub fn quote_vec<'a, S: Into<Quotable<'a>>>(s: S) -> Vec<u8> {
         // Here, previously, in the `Escape` cases, an optimisation
         // precalculated the required capacity of the output `Vec` to avoid
         // reallocations later on, but benchmarks showed that it was slower. It
@@ -164,7 +164,7 @@ impl Bash {
     /// assert_eq!(buf, b"foobar $'foo bar'");
     /// ```
     ///
-    pub fn quote_into_vec<'a, S: ?Sized + Into<Quotable<'a>>>(s: S, sout: &mut Vec<u8>) {
+    pub fn quote_into_vec<'a, S: Into<Quotable<'a>>>(s: S, sout: &mut Vec<u8>) {
         // Here, previously, in the `Escape` cases, an optimisation
         // precalculated the required capacity of the output `Vec` to avoid
         // reallocations later on, but benchmarks showed that it was slower. It

--- a/src/fish.rs
+++ b/src/fish.rs
@@ -42,20 +42,20 @@ use crate::{Quotable, QuoteInto};
 pub struct Fish;
 
 impl QuoteInto<Vec<u8>> for Fish {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut Vec<u8>) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut Vec<u8>) {
         Self::quote_into_vec(s, out);
     }
 }
 
 impl QuoteInto<String> for Fish {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut String) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut String) {
         Self::quote_into_vec(s, unsafe { out.as_mut_vec() })
     }
 }
 
 #[cfg(unix)]
 impl QuoteInto<std::ffi::OsString> for Fish {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut std::ffi::OsString) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut std::ffi::OsString) {
         use std::os::unix::ffi::OsStringExt;
         let s = Self::quote_vec(s);
         let s = std::ffi::OsString::from_vec(s);
@@ -65,7 +65,7 @@ impl QuoteInto<std::ffi::OsString> for Fish {
 
 #[cfg(feature = "bstr")]
 impl QuoteInto<bstr::BString> for Fish {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut bstr::BString) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut bstr::BString) {
         let s = Self::quote_vec(s);
         out.extend(s);
     }
@@ -88,7 +88,7 @@ impl Fish {
     /// assert_eq!(Fish::quote_vec("foobar"), b"foobar");
     /// assert_eq!(Fish::quote_vec("foo 'bar"), b"foo' \\'bar'");
     /// ```
-    pub fn quote_vec<'a, S: ?Sized + Into<Quotable<'a>>>(s: S) -> Vec<u8> {
+    pub fn quote_vec<'a, S: Into<Quotable<'a>>>(s: S) -> Vec<u8> {
         match s.into() {
             Quotable::Bytes(bytes) => match bytes::escape_prepare(bytes) {
                 bytes::Prepared::Empty => vec![b'\'', b'\''],
@@ -126,7 +126,7 @@ impl Fish {
     /// assert_eq!(buf, b"foobar foo' \\'bar'");
     /// ```
     ///
-    pub fn quote_into_vec<'a, S: ?Sized + Into<Quotable<'a>>>(s: S, sout: &mut Vec<u8>) {
+    pub fn quote_into_vec<'a, S: Into<Quotable<'a>>>(s: S, sout: &mut Vec<u8>) {
         match s.into() {
             Quotable::Bytes(bytes) => match bytes::escape_prepare(bytes) {
                 bytes::Prepared::Empty => sout.extend(b"''"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,13 +67,13 @@ pub type Zsh = bash::Bash;
 /// Quoting/escaping a string of bytes into a shell-safe form.
 pub trait QuoteInto<OUT: ?Sized> {
     /// Quote/escape a string of bytes into an existing container.
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut OUT);
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut OUT);
 }
 
 /// Quoting/escaping a string of bytes into a shell-safe form.
 pub trait Quote<OUT: Default>: QuoteInto<OUT> {
     /// Quote/escape a string of bytes into a new container.
-    fn quote<'q, S: ?Sized + Into<Quotable<'q>>>(s: S) -> OUT {
+    fn quote<'q, S: Into<Quotable<'q>>>(s: S) -> OUT {
         let mut out = OUT::default();
         Self::quote_into(s, &mut out);
         out
@@ -92,14 +92,14 @@ pub trait QuoteExt {
     fn push_quoted<'q, Q, S>(&mut self, _q: Q, s: S)
     where
         Q: QuoteInto<Self>,
-        S: ?Sized + Into<Quotable<'q>>;
+        S: Into<Quotable<'q>>;
 }
 
 impl<T: ?Sized> QuoteExt for T {
     fn push_quoted<'q, Q, S>(&mut self, _q: Q, s: S)
     where
         Q: QuoteInto<Self>,
-        S: ?Sized + Into<Quotable<'q>>,
+        S: Into<Quotable<'q>>,
     {
         Q::quote_into(s, self);
     }
@@ -117,7 +117,7 @@ pub trait QuoteRefExt<Output: Default> {
 
 impl<'a, S, OUT: Default> QuoteRefExt<OUT> for S
 where
-    S: ?Sized + Into<Quotable<'a>>,
+    S: Into<Quotable<'a>>,
 {
     fn quoted<Q: Quote<OUT>>(self, _q: Q) -> OUT {
         Q::quote(self)

--- a/src/sh.rs
+++ b/src/sh.rs
@@ -94,14 +94,14 @@ use crate::{ascii::Char, Quotable, QuoteInto};
 pub struct Sh;
 
 impl QuoteInto<Vec<u8>> for Sh {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut Vec<u8>) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut Vec<u8>) {
         Self::quote_into_vec(s, out);
     }
 }
 
 #[cfg(unix)]
 impl QuoteInto<std::ffi::OsString> for Sh {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut std::ffi::OsString) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut std::ffi::OsString) {
         use std::os::unix::ffi::OsStringExt;
         let s = Self::quote_vec(s);
         let s = std::ffi::OsString::from_vec(s);
@@ -111,7 +111,7 @@ impl QuoteInto<std::ffi::OsString> for Sh {
 
 #[cfg(feature = "bstr")]
 impl QuoteInto<bstr::BString> for Sh {
-    fn quote_into<'q, S: ?Sized + Into<Quotable<'q>>>(s: S, out: &mut bstr::BString) {
+    fn quote_into<'q, S: Into<Quotable<'q>>>(s: S, out: &mut bstr::BString) {
         let s = Self::quote_vec(s);
         out.extend(s);
     }
@@ -135,7 +135,7 @@ impl Sh {
     /// assert_eq!(Sh::quote_vec("foo bar"), b"foo' bar'");
     /// ```
     ///
-    pub fn quote_vec<'a, S: ?Sized + Into<Quotable<'a>>>(s: S) -> Vec<u8> {
+    pub fn quote_vec<'a, S: Into<Quotable<'a>>>(s: S) -> Vec<u8> {
         let bytes = match s.into() {
             Quotable::Bytes(bytes) => bytes,
             Quotable::Text(s) => s.as_bytes(),
@@ -170,7 +170,7 @@ impl Sh {
     /// assert_eq!(buf, b"foobar foo' bar'");
     /// ```
     ///
-    pub fn quote_into_vec<'a, S: ?Sized + Into<Quotable<'a>>>(s: S, sout: &mut Vec<u8>) {
+    pub fn quote_into_vec<'a, S: Into<Quotable<'a>>>(s: S, sout: &mut Vec<u8>) {
         let bytes = match s.into() {
             Quotable::Bytes(bytes) => bytes,
             Quotable::Text(s) => s.as_bytes(),


### PR DESCRIPTION
This is because they're all paired with `Into<…>` which has a `Sized` bound.