### PR TITLE
Use `lenient_semver` to parse Fish's new version, 4.0b1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bstr = { version = "1", optional = true }
 
 [dev-dependencies]
 criterion = { version = "^0.5.1", features = ["html_reports"] }
+lenient_semver = "0.4.2"
 semver = "1.0.23"
 test-case = "3.3.1"
 

--- a/tests/test_fish.rs
+++ b/tests/test_fish.rs
@@ -11,7 +11,7 @@ fn fish_version(bin: &Path) -> semver::Version {
     let script = "printf %s $version";
     let output = Command::new(bin).arg("-c").arg(script).output().unwrap();
     let version = String::from_utf8(output.stdout).unwrap();
-    semver::Version::parse(&version).unwrap()
+    lenient_semver::parse(&version).unwrap()
 }
 
 /// The `\\XHH` format (backslash, a literal "X", two hex characters) is


### PR DESCRIPTION
This was necessary while checking that `shell-quote` works okay with [the new 4.0b1 release of Fish](https://fishshell.com/blog/rustport/).