### PR TITLE
Slim down package to be published

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "shell-quote"
 readme = "README.md"
 repository = "https://github.com/allenap/shell-quote"
 version = "0.7.1"
+include = ["LICENSE", "README.md", "src/**/*.rs"]
 
 [features]
 default = ["bstr", "bash", "sh", "fish"]


### PR DESCRIPTION
Previously, things like the `fish` subdirectory were being included, which contained only binaries of `fish` against which I was running tests locally. These are not useful artifacts to publish to crates.io. Indeed, nor are the tests and benchmarks; these are published as part of the source repository of course, however. Fixes #33.