### PR TITLE
Update `criterion` to 0.8, and use `std::hint::black_box`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ sh = []
 bstr = { version = "1", optional = true }
 
 [dev-dependencies]
-criterion = { version = "^0.5.1", features = ["html_reports"] }
-lenient_semver = "0.4.2"
-semver = "1.0.23"
-test-case = "3.3.1"
+criterion = { version = "0.8", features = ["html_reports"] }
+lenient_semver = "0.4"
+semver = "1"
+test-case = "3"
 
 [[bench]]
 name = "bash"

--- a/benches/bash.rs
+++ b/benches/bash.rs
@@ -1,4 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use shell_quote::Bash;
 

--- a/benches/fish.rs
+++ b/benches/fish.rs
@@ -1,4 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use shell_quote::Fish;
 

--- a/benches/sh.rs
+++ b/benches/sh.rs
@@ -1,4 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use shell_quote::Sh;
 


### PR DESCRIPTION
Criterion 0.8 deprecates its own `black_box` re-export in favour of the one in the standard library, stable since Rust 1.66. Without the change to the benchmarks, `cargo clippy --all-targets -- -D warnings` fails – and that is exactly what CI runs.

The other dev-dependencies are relaxed to major/minor versions at the same time; the extra patch-level precision wasn't buying us anything.